### PR TITLE
Add logsBucket and serviceAccount

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,3 +17,5 @@ steps:
     - '--platform=managed'
     - '--allow-unauthenticated'
     - '--image=eu.gcr.io/${PROJECT_ID}/${_SERVICE_NAME}:$SHORT_SHA'
+logsBucket: ${_BUCKET_NAME}
+serviceAccount: ${_SERVICE_ACCOUNT}


### PR DESCRIPTION
logsBucket and serviceAccount are required in response to the changes to the cloud build trigger outlined in https://github.com/cloudacademy/gcp-lab-artifacts/pull/9